### PR TITLE
feat: format instructions properly

### DIFF
--- a/src/components/StyledText.js
+++ b/src/components/StyledText.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+function StyledText({ text, color, backgroundColor }) {
+  return (
+    <span
+      style={{ color, backgroundColor, padding: '3px', borderRadius: '25px' }}
+    >
+      {text}
+    </span>
+  )
+}
+
+export default StyledText

--- a/src/pages/AuthPage.js
+++ b/src/pages/AuthPage.js
@@ -19,6 +19,8 @@ import {
   writeToLocalStorage
 } from '../api/chrome'
 import DialogButton from '../components/DialogButton'
+import StyledText from '../components/StyledText'
+import { COLOR_PRIMARY, COLOR_SECONDARY } from '../constants'
 
 function AuthPage({ isAuthenticated, pat }) {
   const [isLoading, setIsLoading] = useState(false)
@@ -77,7 +79,19 @@ function AuthPage({ isAuthenticated, pat }) {
         and insert it into the box below.
       </Typography>
       <Typography variant="subtitle1" component="sub">
-        Remember to add the `repo` and `read:user` scopes to it.
+        Remember to add the{' '}
+        <StyledText
+          text="repo"
+          color={COLOR_PRIMARY}
+          backgroundColor={COLOR_SECONDARY}
+        />{' '}
+        and{' '}
+        <StyledText
+          text="read:user"
+          color={COLOR_PRIMARY}
+          backgroundColor={COLOR_SECONDARY}
+        />{' '}
+        scopes to it.
       </Typography>
       <Box height={20} />
       <FormControl

--- a/test/components/StyledText.test.js
+++ b/test/components/StyledText.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import StyledText from '../../src/components/StyledText'
+
+const props = {
+  text: 'text',
+  color: '#000000',
+  backgroundColor: '#FFFFFF'
+}
+
+describe('StyledText.js', () => {
+  test('shows the proper StyledText', () => {
+    const tree = renderer.create(<StyledText {...props} />)
+
+    expect(tree.toJSON()).toMatchSnapshot()
+  })
+})

--- a/test/components/__snapshots__/StyledText.test.js.snap
+++ b/test/components/__snapshots__/StyledText.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StyledText.js shows the proper StyledText 1`] = `
+<span
+  style={
+    Object {
+      "backgroundColor": "#FFFFFF",
+      "borderRadius": "25px",
+      "color": "#000000",
+      "padding": "3px",
+    }
+  }
+>
+  text
+</span>
+`;

--- a/test/pages/__snapshots__/AuthPage.test.js.snap
+++ b/test/pages/__snapshots__/AuthPage.test.js.snap
@@ -23,7 +23,37 @@ exports[`AuthPage.js renders the Auth Page for authenticated users 1`] = `
   <sub
     className="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
   >
-    Remember to add the \`repo\` and \`read:user\` scopes to it.
+    Remember to add the
+     
+    <span
+      style={
+        Object {
+          "backgroundColor": "#FB7A9C",
+          "borderRadius": "25px",
+          "color": "#140048",
+          "padding": "3px",
+        }
+      }
+    >
+      repo
+    </span>
+     
+    and
+     
+    <span
+      style={
+        Object {
+          "backgroundColor": "#FB7A9C",
+          "borderRadius": "25px",
+          "color": "#140048",
+          "padding": "3px",
+        }
+      }
+    >
+      read:user
+    </span>
+     
+    scopes to it.
   </sub>
   <div
     className="MuiBox-root css-1pg8bi"
@@ -220,7 +250,37 @@ exports[`AuthPage.js renders the Auth Page for unauthenticated users 1`] = `
   <sub
     className="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
   >
-    Remember to add the \`repo\` and \`read:user\` scopes to it.
+    Remember to add the
+     
+    <span
+      style={
+        Object {
+          "backgroundColor": "#FB7A9C",
+          "borderRadius": "25px",
+          "color": "#140048",
+          "padding": "3px",
+        }
+      }
+    >
+      repo
+    </span>
+     
+    and
+     
+    <span
+      style={
+        Object {
+          "backgroundColor": "#FB7A9C",
+          "borderRadius": "25px",
+          "color": "#140048",
+          "padding": "3px",
+        }
+      }
+    >
+      read:user
+    </span>
+     
+    scopes to it.
   </sub>
   <div
     className="MuiBox-root css-1pg8bi"


### PR DESCRIPTION
Closes https://github.com/nearform/github-snooze-chrome-extension/issues/22

Updated the instructions from markdown format to custom format with a new StyledText component (badge-simil).

<img width="497" alt="Screenshot 2022-08-02 at 16 09 52" src="https://user-images.githubusercontent.com/6604111/182395713-b2ca6d10-e1da-4fd9-8c88-52ca865b7320.png">

