### PR TITLE
Feat/release automation 1st step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: nearform/optic-release-automation-action@feat/add-release-artifact
+      - uses: nearform/optic-release-automation-action@v3
         with:
           github-token: ${{ secrets.github_token }}
           semver: ${{ github.event.inputs.semver }}


### PR DESCRIPTION
Closes https://github.com/nearform/github-snooze-chrome-extension/issues/18

This PR adds the release workflow to the GitHub Snooze Chrome extension in order to create an asset with the Chrome Extension when a release is created.