### PR TITLE
feat: hide notification badge

### DIFF
--- a/src/api/chrome.js
+++ b/src/api/chrome.js
@@ -170,7 +170,7 @@ export const incrementBadgeCounter = async (increment = 1) => {
  */
 export const updateBadgeCounterUI = async () => {
   const badgeCounter = await getBadgeCounter()
-  let text = badgeCounter > 0 ? badgeCounter.toString() : ''
+  const text = badgeCounter > 0 ? badgeCounter.toString() : ''
 
   chrome.action.setBadgeBackgroundColor({ color: COLOR_SECONDARY })
   chrome.action.setBadgeText({ text })


### PR DESCRIPTION
Fixes https://github.com/nearform/github-snooze-chrome-extension/issues/30

Hide the notification badge if the badge counter is less than 1.