### PR TITLE
feat: update readme including chrome extension link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ To use this extension you will need to [generate a GitHub Personal Access Token 
 - `repo`: used for getting the repository information, such as last update date time on issues and pull requests
 - `read:user`: used for retrieving the current logged in user information _(GitHub ID and username)_
 
+## Installation via the Chrome Web Store
+The [GitHub Snooze Extension](https://chrome.google.com/webstore/detail/github-snooze/jeecjllabmgondbmnnlogkkaafjcgbck) is available in the Chrome Web Store. You can install it as a regular extension.
+
 ## Usage instructions for the users
 In order to use this extension locally, you have to complete the following steps:
 


### PR DESCRIPTION
closes https://github.com/nearform/github-snooze-chrome-extension/issues/61

add Installation via the Chrome Web Store section to the readme file.