### PR TITLE
feat: update curl command

### DIFF
--- a/.github/workflows/chrome-web-store-automation.yml
+++ b/.github/workflows/chrome-web-store-automation.yml
@@ -10,7 +10,7 @@ jobs:
     name: Publish an update to the Chrome Web Store
     steps:
       - name: Download release artifact
-        run: curl ${{ github.event.release.assets[0].browser_download_url }} -o ${{ github.event.release.assets[0].name }}
+        run: curl -LO ${{ github.event.release.assets[0].browser_download_url }}
       - name: Publish to the Chrome Web Store
         uses: mnao305/chrome-extension-upload@3.0.0
         with:

--- a/.github/workflows/chrome-web-store-automation.yml
+++ b/.github/workflows/chrome-web-store-automation.yml
@@ -10,7 +10,7 @@ jobs:
     name: Publish an update to the Chrome Web Store
     steps:
       - name: Download release artifact
-        run: curl -LO ${{ github.event.release.assets[0].browser_download_url }}
+        run: curl --fail-with-body -LO ${{ github.event.release.assets[0].browser_download_url }}
       - name: Publish to the Chrome Web Store
         uses: mnao305/chrome-extension-upload@3.0.0
         with:


### PR DESCRIPTION
Closes https://github.com/nearform/github-snooze-chrome-extension/issues/77

Update curl command from:

`curl {url} -o {filename}`

to 

`curl --fail-with-body -LO {url}`