### PR TITLE
fix: service worker is not sending notifications

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -19,8 +19,7 @@ import {
 import { dateHasPassed } from './date'
 import { isValidUrl } from './url'
 
-const CHECK_INTERVAL_TIMER = 60000
-
+const CHECK_INTERVAL_TIMER_MINUTES = 1
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   const { action, msg: badgeCounter } = message
   switch (action) {
@@ -66,7 +65,12 @@ chrome.tabs.onActivated.addListener(async activeInfo => {
   await writeToLocalStorage({ url })
 })
 
-setInterval(async () => {
+chrome.alarms.create({
+  periodInMinutes: CHECK_INTERVAL_TIMER_MINUTES,
+  when: Date.now() + 1
+})
+
+chrome.alarms.onAlarm.addListener(async () => {
   const now = new Date()
 
   const localStorage = await readAllFromLocalStorage()
@@ -92,7 +96,7 @@ setInterval(async () => {
   await updateBadgeCounterUI()
 
   await setSnoozeList(user.id, updatedSnoozeList)
-}, CHECK_INTERVAL_TIMER)
+})
 
 const notify = async (snooze, pat) => {
   const { entityInfo } = snooze

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,12 +17,7 @@
       "128": "images/128.png"
     }
   },
-  "permissions": [
-    "tabs",
-    "storage",
-    "background",
-    "notifications"
-  ],
+  "permissions": ["tabs", "alarms", "storage", "background", "notifications"],
   "icons": {
     "16": "images/16.png",
     "32": "images/32.png",


### PR DESCRIPTION
Closes #94
background script's `setInterval` was replaced by using `alarms` API and events according to the docs https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/#alarms