### PR TITLE
Update github-action-merge-dependabot to pre release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3
+      - uses: guilhermelimak/github-action-merge-dependabot@feat/use-fetch-metadata-action


### PR DESCRIPTION
For the github-action-merge-dependabot's [newest version](https://github.com/fastify/github-action-merge-dependabot/pull/276) we have updated how the dependabot PR metadata is retrieved.  Before that it used some custom logic to parse the PR title and branch name but now we use dependabot's fetch-metadata action which does all the heavy lifting for us. Since that was quite a big change we're deploying a prerelease version for a small amount of projects to do before fully releasing it. 

This should be replaced back to the original after github-action-merge-dependabot is merged.