### PR TITLE
fix: get url on app init not relying on local storage

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -13,11 +13,9 @@ import {
   ACTION_GET_CURRENT_TAB_URL,
   ACTION_UPDATE_BADGE_COUNTER,
   SNOOZE_STATUS_DONE,
-  SNOOZE_STATUS_PENDING,
-  URL_MATCH
+  SNOOZE_STATUS_PENDING
 } from './constants'
 import { dateHasPassed } from './date'
-import { isValidUrl } from './url'
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   const { action, msg: badgeCounter } = message
@@ -37,31 +35,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 
   sendResponse()
-})
-
-chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-  let url = ''
-
-  if (changeInfo.url === undefined) {
-    url = tab.url
-  } else {
-    url = changeInfo.url
-  }
-
-  if (!isValidUrl(url, URL_MATCH)) {
-    url = null
-  }
-
-  await writeToLocalStorage({ url })
-})
-
-chrome.tabs.onActivated.addListener(async activeInfo => {
-  const tab = await chrome.tabs.get(activeInfo.tabId)
-  let { url } = tab
-  if (!url || !isValidUrl(url, URL_MATCH)) {
-    url = null
-  }
-  await writeToLocalStorage({ url })
 })
 
 export const createChromeAlarm = checkIntervalTimerMinutes => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,7 +41,6 @@ export const COLOR_WARNING = '#D47709'
  * Storage Keys
  */
 export const SK_BADGE_COUNTER = 'badgeCounter'
-export const SK_URL = 'url'
 export const SK_USER = 'user'
 export const SK_PAT = 'pat'
 

--- a/src/hooks/useInitApp.js
+++ b/src/hooks/useInitApp.js
@@ -7,7 +7,6 @@ import {
 } from '../api/chrome'
 import { getUserByPat } from '../api/github'
 import {
-  SK_URL,
   SK_PAT,
   SK_USER,
   SET_LOADING,
@@ -45,16 +44,12 @@ function useInitApp() {
     dispatch({ type: SET_LOADING, payload: true })
     const init = async () => {
       try {
-        const storage = await readFromLocalStorage([SK_URL, SK_PAT, SK_USER])
-        const { pat, url: urlFromStorage } = storage
-        let url = urlFromStorage
+        const { pat } = await readFromLocalStorage([SK_PAT, SK_USER])
         if (!pat) {
           throw Error('PAT not available.')
         }
-        if (!url) {
-          url = await getCurrentTabUrl()
-          await writeToLocalStorage({ url })
-        }
+        const url = await getCurrentTabUrl()
+
         const userData = await getUserByPat(pat)
         const { login, id: userId } = userData
         if (!login) {


### PR DESCRIPTION
Closes #202 

As discussed in the issue, the url written in chrome's local storage was outdated in some cases. I removed the url from the storage and getting it when the app mounts, which is safe to assume considering the react app is a chrome extension and the mounts every time we open it.