### PR TITLE
fix: 282: use openssl-legacy-provider flag when running storybook locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "vite",
     "update-manifest": "node ./scripts/updateManifest.js",
     "test": "cross-env TZ=UTC jest",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "node --openssl-legacy-provider ./node_modules/.bin/start-storybook -p 6006",
     "test-storybook": "node --openssl-legacy-provider ./node_modules/.bin/test-storybook --url http://127.0.0.1:6006",
     "test-storybook:ci": "node ./storybook-test-runner.js",
     "build-storybook": "node --openssl-legacy-provider ./node_modules/.bin/build-storybook --quiet",


### PR DESCRIPTION
- closes https://github.com/nearform/github-snooze-chrome-extension/issues/282