### PR TITLE
fix: 377: decrement badge counter when a snooze is reopened

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,7 +81,7 @@ const App = () => {
       status: SNOOZE_STATUS_PENDING
     }
 
-    const updatedSnoozeList = await updateSnooze(user.id, updatedSnooze)
+    const updatedSnoozeList = await updateSnooze({ userId: user.id, updatedSnooze, oldSnooze: snooze })
     setSnoozeList(updatedSnoozeList)
 
     setErrorMessage('')


### PR DESCRIPTION
- closes https://github.com/nearform/github-snooze-chrome-extension/issues/377
- when a snooze is being rescheduled, we should decrement/hide the badge counter