### PR TITLE
fix: 421: when the user logs out, the badge counter should be reset

### DIFF
--- a/src/api/chrome.js
+++ b/src/api/chrome.js
@@ -151,7 +151,7 @@ export const removeSnooze = async (userId, snooze) => {
   })
 
   await setSnoozeList(userId, updatedList)
-  const badgeCounter = await getBadgeCounter(userId)
+  const badgeCounter = await getBadgeCounter()
 
   if (badgeCounter > 0 && oldSnooze.status === SNOOZE_STATUS_DONE && oldSnooze.status !== updatedSnooze.status) {
     // the snooze has been "reopened"
@@ -192,6 +192,15 @@ export const incrementBadgeCounter = async (increment = 1) => {
   badgeCounter += increment
   await writeToSyncStorage({ badgeCounter })
   return badgeCounter
+}
+
+/**
+ * Resets the badge counter value to 0.
+ * @returns void
+ */
+export const resetBadgeCounter = async () => {
+  await writeToSyncStorage({ badgeCounter: 0 })
+  await sendMessage(ACTION_UPDATE_BADGE_COUNTER, 0)
 }
 
 /**

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -18,6 +18,7 @@ import { getUserByPat } from '../api/github'
 import {
   clearLocalStorage,
   clearSyncStorage,
+  resetBadgeCounter,
   writeToLocalStorage
 } from '../api/chrome'
 import DialogButton from '../components/DialogButton'
@@ -72,6 +73,7 @@ function AuthPage({ isAuthenticated, pat }) {
 
   const handleLogout = async () => {
     await clearLocalStorage()
+    await resetBadgeCounter()
     window.location.reload()
   }
 

--- a/test/chrome.test.js
+++ b/test/chrome.test.js
@@ -1,4 +1,4 @@
-import { getCurrentTabUrl, updateSnooze } from '../src/api/chrome'
+import { getCurrentTabUrl, resetBadgeCounter, updateSnooze } from '../src/api/chrome'
 import { ACTION_UPDATE_BADGE_COUNTER, SK_BADGE_COUNTER, SNOOZE_STATUS_DONE, SNOOZE_STATUS_PENDING } from '../src/constants'
 
 const cleanup = () => {
@@ -108,5 +108,24 @@ test('correctly decrease the badge counter if a snooze item is being reopened', 
   expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
     action: ACTION_UPDATE_BADGE_COUNTER,
     msg: 1,
+  })
+})
+
+test('correctly reset the badge counter if the reset function is called', async () => {
+  const userId = 1
+  const snoozeId = 1
+
+  storageSyncGetSpy.mockResolvedValue({
+    [userId]: [{ id: snoozeId, status: SNOOZE_STATUS_DONE }],
+    [SK_BADGE_COUNTER]: 1,
+  })
+
+  storageSyncSetSpy.mockResolvedValue(null)
+
+  await resetBadgeCounter()
+  // if the chrome.runtime.sendMessage has been called, it means that the badge counter has been decreased
+  expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+    action: ACTION_UPDATE_BADGE_COUNTER,
+    msg: 0,
   })
 })


### PR DESCRIPTION
- closes https://github.com/nearform/github-snooze-chrome-extension/issues/421