### PR TITLE
feat: (wip)track discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You will need to:
     - `Issues`
     - `Pull requests`
     - `Metadata` (should be set automatically when you set it for `Issues` or `Pull requests`)
+    - `Discussions` - currently not available with fine-grained PATs
 
 #### Generating a Classic PAT
 You will need to:
@@ -39,6 +40,7 @@ You will need to:
 - select the following scopes:
     - `repo`: used for getting the repository information, such as last update date time on issues and pull requests
     - `read:user`: used for retrieving the current logged in user information _(GitHub ID and username)_
+    - `write:discussions`: used to have access to the discussions API
 
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You will need to:
 - select the following scopes:
     - `repo`: used for getting the repository information, such as last update date time on issues and pull requests
     - `read:user`: used for retrieving the current logged in user information _(GitHub ID and username)_
-    - `write:discussions`: used to have access to the discussions API
+    - `read:discussions`: used to have access to the discussions API
 
 
 ## Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,11 @@
         "@mui/material": "^5.11.4",
         "@vitejs/plugin-react": "^3.0.1",
         "chrono-node": "^2.5.0",
+        "graphql": "^16.6.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.6.2",
+        "urql": "^3.0.3",
         "uuid": "^9.0.0",
         "webextension-polyfill": "^0.10.0"
       },
@@ -17465,6 +17467,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@urql/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
+      "dependencies": {
+        "wonka": "^6.1.2"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.0.1.tgz",
@@ -25092,6 +25105,14 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
+    },
+    "node_modules/graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -38311,6 +38332,19 @@
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "dev": true
     },
+    "node_modules/urql": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/urql/-/urql-3.0.3.tgz",
+      "integrity": "sha512-aVUAMRLdc5AOk239DxgXt6ZxTl/fEmjr7oyU5OGo8uvpqu42FkeJErzd2qBzhAQ3DyusoZIbqbBLPlnKo/yy2A==",
+      "dependencies": {
+        "@urql/core": "^3.0.3",
+        "wonka": "^6.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -39708,6 +39742,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wonka": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.2.tgz",
+      "integrity": "sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -52607,6 +52646,14 @@
         "@types/node": "*"
       }
     },
+    "@urql/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
+      "requires": {
+        "wonka": "^6.1.2"
+      }
+    },
     "@vitejs/plugin-react": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.0.1.tgz",
@@ -58632,6 +58679,11 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
+    },
+    "graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
     "handlebars": {
       "version": "4.7.7",
@@ -68782,6 +68834,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "urql": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/urql/-/urql-3.0.3.tgz",
+      "integrity": "sha512-aVUAMRLdc5AOk239DxgXt6ZxTl/fEmjr7oyU5OGo8uvpqu42FkeJErzd2qBzhAQ3DyusoZIbqbBLPlnKo/yy2A==",
+      "requires": {
+        "@urql/core": "^3.0.3",
+        "wonka": "^6.0.0"
+      }
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -69884,6 +69945,11 @@
           }
         }
       }
+    },
+    "wonka": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.2.tgz",
+      "integrity": "sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^5.11.0",
         "@mui/lab": "^5.0.0-alpha.115",
         "@mui/material": "^5.11.4",
+        "@urql/exchange-auth": "^1.0.0",
         "@vitejs/plugin-react": "^3.0.1",
         "chrono-node": "^2.5.0",
         "graphql": "^16.6.0",
@@ -17473,6 +17474,18 @@
       "integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
       "dependencies": {
         "wonka": "^6.1.2"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@urql/exchange-auth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-auth/-/exchange-auth-1.0.0.tgz",
+      "integrity": "sha512-79hqPQab+ifeINOxvQykvqub4ixWHBEIagN4U67ijcHGMfp3c4yEWRk4IJMPwF+OMT7LrRFuv+jRIZTQn/9VwQ==",
+      "dependencies": {
+        "@urql/core": ">=3.0.0",
+        "wonka": "^6.0.0"
       },
       "peerDependencies": {
         "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -52652,6 +52665,15 @@
       "integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
       "requires": {
         "wonka": "^6.1.2"
+      }
+    },
+    "@urql/exchange-auth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-auth/-/exchange-auth-1.0.0.tgz",
+      "integrity": "sha512-79hqPQab+ifeINOxvQykvqub4ixWHBEIagN4U67ijcHGMfp3c4yEWRk4IJMPwF+OMT7LrRFuv+jRIZTQn/9VwQ==",
+      "requires": {
+        "@urql/core": ">=3.0.0",
+        "wonka": "^6.0.0"
       }
     },
     "@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@mui/icons-material": "^5.11.0",
     "@mui/lab": "^5.0.0-alpha.115",
     "@mui/material": "^5.11.4",
+    "@urql/exchange-auth": "^1.0.0",
     "@vitejs/plugin-react": "^3.0.1",
     "chrono-node": "^2.5.0",
     "graphql": "^16.6.0",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "@mui/material": "^5.11.4",
     "@vitejs/plugin-react": "^3.0.1",
     "chrono-node": "^2.5.0",
+    "graphql": "^16.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.6.2",
+    "urql": "^3.0.3",
     "uuid": "^9.0.0",
     "webextension-polyfill": "^0.10.0"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,7 +70,7 @@ const App = () => {
       return setErrorMessage('Please set a date in the future')
     }
 
-    const entityInfo = getEntityInfo(snooze.url)  
+    const entityInfo = getEntityInfo(snooze.url)
     const entity = await getEntity(entityInfo, pat)
 
     if (entity?.error) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,9 @@ import { addSnooze, checkUrlAlreadySnoozed, getSnoozeList, updateSnooze } from '
 import { getEntityInfo } from './parser'
 import { getEntity } from './api/github'
 import { SNOOZE_STATUS_PENDING } from './constants'
+import { DISCUSSION_QUERY } from './graphql/queries'
 import RoutesWrapper from './components/RoutesWrapper'
+import { useQuery } from 'urql';
 
 const App = () => {
   const {
@@ -22,6 +24,42 @@ const App = () => {
   } = useInitApp()
   const [errorMessage, setErrorMessage] = useState('')
   const [snoozeList, setSnoozeList] = useState(snoozes)
+  // const [snoozeType, setSnoozeType] = useState('')
+
+  const entityInfo = !currentUrl || getEntityInfo(currentUrl)
+  const {  number, owner, repo } = entityInfo
+
+  const [result, executeQuery] = useQuery({
+    query: DISCUSSION_QUERY,
+    variables: {
+      number: parseInt(number),
+      owner: owner,
+      name: repo
+    },
+    pause: true // execute query manually
+  });
+
+  const { data, fetching, error } = result
+
+  useEffect(() => {
+    if (error?.message) { 
+      setErrorMessage(error.message) // Maybe put generic message "Something went wrong...."
+    }
+
+    if(data) {
+      // const updatedAt = data?.repository.discussions.updated_at
+      // const snooze = {
+      //   id: uuid.v4(),
+      //   url: currentUrl,
+      //   // notifyAt: notifyDate.getTime(), need to add a hook to pass the notify date
+      //   entityInfo: { ...entityInfo, updatedAt },
+      //   status: SNOOZE_STATUS_PENDING
+      // }
+      // const useAddSnooze = async () => await addSnooze(user.id, snooze) // "useAddSnooze" cannot be called inside a callback
+      // const updatedSnoozeList = useAddSnooze() // update snooze list based on snoozeType
+      // setSnoozeList(updatedSnoozeList)
+    }
+  }, [fetching, error, data]) 
 
   const handleAddSnooze = async notifyDate => {
     setErrorMessage('')
@@ -37,13 +75,23 @@ const App = () => {
     }
 
     const entityInfo = getEntityInfo(currentUrl)
-    const entity = await getEntity(entityInfo, pat)
+    const { type } = entityInfo
+    let entity
+    if (type === 'discussions') {
+      await executeQuery() // await doesn't seem to wait for the query response
+      // setSnoozeType('add')
+      return // do the rest in the effect, when data is ready
+    }
+    else {
+      entity = await getEntity(entityInfo, pat)
+    }
 
     if (entity.message === 'Not Found') {
       return setErrorMessage(
         'The provided URL is not valid. Unable to fetch entity information from GitHub.'
       )
     }
+
     const { updated_at: updatedAt } = entity
 
     const snooze = {

--- a/src/graphql/client.js
+++ b/src/graphql/client.js
@@ -5,21 +5,23 @@ import { SK_PAT, SK_USER } from '../constants';
 import { readFromLocalStorage } from '../api/chrome';
 
 const getAuth = async ({ authState }) => {
-  if (!authState) {
-      const { pat } = await readFromLocalStorage([SK_PAT, SK_USER])
-
-      if (!pat) {
-          throw Error('PAT not available.') 
-      }
-
-      return { token: pat }
+  if (authState) {
+    return {
+      token: null
+    };
   }
 
-  return null;
+  const { pat } = await readFromLocalStorage([SK_PAT, SK_USER])
+
+  if (!pat) {
+      throw Error('PAT not available.') 
+  }
+
+  return { token: pat }
 };
 
 const addAuthToOperation = ({ authState, operation }) => {
-  if (!authState || !authState.token) {
+  if (!authState?.token) {
     return operation;
   }
 

--- a/src/graphql/client.js
+++ b/src/graphql/client.js
@@ -1,0 +1,59 @@
+import { createClient, dedupExchange, cacheExchange, fetchExchange } from 'urql';
+import { authExchange } from '@urql/exchange-auth';
+import { makeOperation } from '@urql/core';
+import { SK_PAT, SK_USER } from '../constants';
+import { readFromLocalStorage } from '../api/chrome';
+
+const getAuth = async ({ authState }) => {
+  if (!authState) {
+      const { pat } = await readFromLocalStorage([SK_PAT, SK_USER])
+
+      if (!pat) {
+          throw Error('PAT not available.') 
+      }
+
+      return { token: pat }
+  }
+
+  return null;
+};
+
+const addAuthToOperation = ({ authState, operation }) => {
+  if (!authState || !authState.token) {
+    return operation;
+  }
+
+  const fetchOptions =
+    typeof operation.context.fetchOptions === 'function'
+      ? operation.context.fetchOptions()
+      : operation.context.fetchOptions || {};
+
+  return makeOperation(operation.kind, operation, {
+    ...operation.context,
+    fetchOptions: {
+      ...fetchOptions,
+      headers: {
+        ...fetchOptions.headers,
+        Authorization: `Bearer ${authState.token}`,
+      },
+    },
+  });
+};
+
+const didAuthError = ({ error }) => {
+  return error.graphQLErrors.some(e => e.extensions?.code === 'FORBIDDEN');
+};
+
+export const getGraphqlClient = () => createClient({
+  url: 'https://api.github.com/graphql',
+  exchanges: [
+      dedupExchange,
+      cacheExchange,
+      authExchange({
+          addAuthToOperation,
+          didAuthError,
+          getAuth,
+        }),
+      fetchExchange
+    ]
+});

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -1,5 +1,5 @@
 export const DISCUSSION_QUERY = `
-  query Discussion($owner: String! , $name: String!, $number: Int! ) {
+  query Discussion($owner: String!, $name: String!, $number: Int!) {
     repository(owner: $owner, name: $name) {
       discussion(number: $number) {
         updatedAt

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -1,0 +1,9 @@
+export const DISCUSSION_QUERY = `
+  query Discussion($owner: String! , $name: String!, $number: Int! ) {
+    repository(owner: $owner, name: $name) {
+      discussion(number: $number) {
+        updatedAt
+      }
+    }
+  }
+`

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,32 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import { readFromLocalStorage } from './api/chrome'
-import { createClient, Provider } from 'urql';
-import {
-    SK_PAT,
-    SK_USER,
-  } from './constants'
-
 import App from './App'
-
-const client = createClient({
-    url: 'https://api.github.com/graphql',
-    fetchOptions: async () => {
-        const { pat } =  await readFromLocalStorage([SK_PAT, SK_USER])
-        
-        if (!pat) {
-            throw Error('PAT not available.')
-        }
-        return {
-            headers: { authorization: `Bearer ${pat}` },
-        };
-    },
-});
 
 const root = createRoot(document.getElementById('root'))
 
-root.render(
-    <Provider value={client}>
-        <App />
-    </Provider>,
-)
+root.render(<App />)

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,8 +1,32 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
+import { readFromLocalStorage } from './api/chrome'
+import { createClient, Provider } from 'urql';
+import {
+    SK_PAT,
+    SK_USER,
+  } from './constants'
 
 import App from './App'
 
+const client = createClient({
+    url: 'https://api.github.com/graphql',
+    fetchOptions: async () => {
+        const { pat } =  await readFromLocalStorage([SK_PAT, SK_USER])
+        
+        if (!pat) {
+            throw Error('PAT not available.')
+        }
+        return {
+            headers: { authorization: `Bearer ${pat}` },
+        };
+    },
+});
+
 const root = createRoot(document.getElementById('root'))
 
-root.render(<App />)
+root.render(
+    <Provider value={client}>
+        <App />
+    </Provider>,
+)

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -139,12 +139,18 @@ function AuthPage({ isAuthenticated, pat }) {
             <StyledText as="span">Issues</StyledText> and{' '}
             <StyledText as="span">Pull requests</StyledText>
           </Typography>
+          <Typography component="p">
+            NOTE:
+          </Typography>
+          <Typography component="p">
+            - The <StyledText as="span">Discussions</StyledText> permission is not available for fine-grained PATs.
+          </Typography>
         </>
       }
       {tokenType === TOKEN_TYPES.CLASSIC && <>
           <Typography variant="subtitle1" component="sub">
-            Set the following scopes: <StyledText as="span">repo</StyledText> and{' '}
-            <StyledText as="span">read:user</StyledText>.
+            Set the following scopes: <StyledText as="span">repo</StyledText>, <StyledText as="span">read:user</StyledText> and{' '}
+            <StyledText as="span">write:discussions</StyledText>.
           </Typography>
         </>
       }

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -150,7 +150,7 @@ function AuthPage({ isAuthenticated, pat }) {
       {tokenType === TOKEN_TYPES.CLASSIC && <>
           <Typography variant="subtitle1" component="sub">
             Set the following scopes: <StyledText as="span">repo</StyledText>, <StyledText as="span">read:user</StyledText> and{' '}
-            <StyledText as="span">write:discussions</StyledText>.
+            <StyledText as="span">read:discussions</StyledText>.
           </Typography>
         </>
       }

--- a/test/chrome.test.js
+++ b/test/chrome.test.js
@@ -10,7 +10,6 @@ const cleanup = () => {
 
 let sendResponseSpy, storageSyncGetSpy, storageSyncSetSpy
 
-
 beforeEach(() => {
   cleanup()
   const originalImpl = global.chrome.runtime.onMessage.addListener // prevent infinite-loop

--- a/test/components/__snapshots__/SnoozeItem.test.jsx.snap
+++ b/test/components/__snapshots__/SnoozeItem.test.jsx.snap
@@ -85,7 +85,7 @@ exports[`SnoozeItem shows the proper SnoozeItem - future notification date 1`] =
       <h6
         class="MuiTypography-root MuiTypography-subtitle1 css-i5mk92-MuiTypography-root"
       >
-        Scheduled for Jul 28 2200 10:00
+        Scheduled for Jul 28 2200 12:00
       </h6>
     </div>
   </div>
@@ -177,7 +177,7 @@ exports[`SnoozeItem shows the proper SnoozeItem - past notification date 1`] = `
       <h6
         class="MuiTypography-root MuiTypography-subtitle1 css-i5mk92-MuiTypography-root"
       >
-        Notified at Jul 28 2022 10:00
+        Notified at Jul 28 2022 12:00
       </h6>
     </div>
   </div>

--- a/test/components/__snapshots__/SnoozeItem.test.jsx.snap
+++ b/test/components/__snapshots__/SnoozeItem.test.jsx.snap
@@ -85,7 +85,7 @@ exports[`SnoozeItem shows the proper SnoozeItem - future notification date 1`] =
       <h6
         class="MuiTypography-root MuiTypography-subtitle1 css-i5mk92-MuiTypography-root"
       >
-        Scheduled for Jul 28 2200 12:00
+        Scheduled for Jul 28 2200 10:00
       </h6>
     </div>
   </div>
@@ -177,7 +177,7 @@ exports[`SnoozeItem shows the proper SnoozeItem - past notification date 1`] = `
       <h6
         class="MuiTypography-root MuiTypography-subtitle1 css-i5mk92-MuiTypography-root"
       >
-        Notified at Jul 28 2022 12:00
+        Notified at Jul 28 2022 10:00
       </h6>
     </div>
   </div>

--- a/test/pages/__snapshots__/AuthPage.test.jsx.snap
+++ b/test/pages/__snapshots__/AuthPage.test.jsx.snap
@@ -163,6 +163,22 @@ exports[`AuthPage.js renders the Auth Page for authenticated users 1`] = `
       Pull requests
     </span>
   </sub>
+  <p
+    class="MuiTypography-root MuiTypography-body1 css-14sfki5-MuiTypography-root"
+  >
+    NOTE:
+  </p>
+  <p
+    class="MuiTypography-root MuiTypography-body1 css-14sfki5-MuiTypography-root"
+  >
+    - The 
+    <span
+      class="css-jqunji"
+    >
+      Discussions
+    </span>
+     permission is not available for fine-grained PATs.
+  </p>
   <div
     class="MuiBox-root css-1pg8bi"
   />
@@ -433,6 +449,22 @@ exports[`AuthPage.js renders the Auth Page for unauthenticated users 1`] = `
       Pull requests
     </span>
   </sub>
+  <p
+    class="MuiTypography-root MuiTypography-body1 css-14sfki5-MuiTypography-root"
+  >
+    NOTE:
+  </p>
+  <p
+    class="MuiTypography-root MuiTypography-body1 css-14sfki5-MuiTypography-root"
+  >
+    - The 
+    <span
+      class="css-jqunji"
+    >
+      Discussions
+    </span>
+     permission is not available for fine-grained PATs.
+  </p>
   <div
     class="MuiBox-root css-1pg8bi"
   />

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -20,4 +20,14 @@ describe('parser.js', () => {
     expect(entityInfo.type).toBe('issues')
     expect(entityInfo.number).toBe('50')
   })
+
+  test('should return the proper entity info with a valid url - discussion', () => {
+    const url = 'https://github.com/owner/repo/discussions/50'
+    const entityInfo = getEntityInfo(url)
+    expect(entityInfo).toBeDefined()
+    expect(entityInfo.owner).toBe('owner')
+    expect(entityInfo.repo).toBe('repo')
+    expect(entityInfo.type).toBe('discussions')
+    expect(entityInfo.number).toBe('50')
+  })
 })

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -9,6 +9,12 @@ describe('url.js', () => {
     expect(isValid).toBe(true)
   })
 
+  test('it should return true if the URL is valid - discussions', () => {
+    const url = 'https://github.com/owner/repo/discussions/24'
+    const isValid = isValidUrl(url, URL_MATCH)
+    expect(isValid).toBe(true)
+  })
+
   test('it should return false if the URL is not valid', () => {
     const url = 'https://example.com/something'
     const isValid = isValidUrl(url, URL_MATCH)


### PR DESCRIPTION
This is a work in progress (functionality NOT finished)

This ticket closes https://github.com/nearform/github-snooze-chrome-extension/issues/402

Context: Add the ability to support Discussions (not PR discussions or Team Discussions) 

Steps to test:
- Follow all the steps from readme and use [Classic PAT](https://github.com/settings/tokens/new) NOT [Fine-grained PAT](https://github.com/settings/personal-access-tokens/new).
- Navigate to a repository that has "Discussions" enabled, for example https://github.com/nearform/graphql-hooks/discussions/789
<img width="1042" alt="Screenshot 2023-01-13 at 18 22 51" src="https://user-images.githubusercontent.com/3214357/212380877-1380514f-9cbe-4e47-b17d-98f96838da07.png">
- Create snooze 
<img width="564" alt="Screenshot 2023-01-13 at 13 54 48" src="https://user-images.githubusercontent.com/3214357/212380623-24d9800b-a7d1-4f47-b3e4-34b65fe86536.png">


Known issues:
- Github doesn't allow graphql requests using [Fine-grained PAT](https://github.com/settings/personal-access-tokens/new)
- The PAT token doesn't seem to load in time and request appear unauthenticated (in index.jsx, createClient, L15)
- urql uses hooks and adding/updating is handled all in a callback, there needs to be a way to wait for executeQuery to retreive data 
