### PR TITLE
Fix/462 point to the latest v4 version optic release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: nearform/optic-release-automation-action@feat/add-monorepo-support
+      - uses: nearform/optic-release-automation-action@v4
         with:
           github-token: ${{ secrets.github_token }}
           semver: ${{ github.event.inputs.semver }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
           - patch
           - minor
           - major
+      baseTag:
+        description: 'base release tag'
   pull_request:
     types: [closed]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ on:
           - patch
           - minor
           - major
-      baseTag:
-        description: 'base release tag'
   pull_request:
     types: [closed]
 


### PR DESCRIPTION
It closes https://github.com/nearform/github-snooze-chrome-extension/issues/462

### Main changes:

- optic-release-automation-action: point to the latest v4 release
- optic-release-automation-action: add support to base release (baseTag)