### PR TITLE
Pin optic-release-automation-action to pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: nearform/optic-release-automation-action@v4
+      - uses: nearform/optic-release-automation-action@feat/add-monorepo-support
         with:
           github-token: ${{ secrets.github_token }}
           semver: ${{ github.event.inputs.semver }}


### PR DESCRIPTION
Pin optic-release-automation-action to pre-release version containing monorepo support.

This should be changed back to the normal version later after confirming the pre-release is working correctly.

Reference nearform/optic-release-automation-action#186.